### PR TITLE
Add `ansi` flag, use getopt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 cmake-*
 build/
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 .PHONY: build clean
 
+CC = gcc
+CFLAGS = -ansi -Wall -Wpedantic -Wshadow -std=gnu99
+
 build: waitport
 
 waitport: lib.h lib.c main.c
-	gcc -o waitport -Os -s --std=c99 -Wall -Wpedantic -I. lib.c main.c
+	$(CC) -o waitport lib.c main.c $(CFLAGS)
 
 clean:
 	rm -f waitport


### PR DESCRIPTION
https://www.man7.org/linux/man-pages/man3/getopt.3.html
Add `getopt` parsing.
- `-p port` must be given, the application does not resolve it without a flag `p`. But the order is not important. This situation is valid for all arguments.
- Added a new flag for host which is `-h` and has a default value as localhost in case of not being supplied by the user.

Added `-ansi`, `-Wshadow`.
Removed `-0s` and `-s`, because they gave a warning with `ansi` flag.
Replaced `CLOCK_MONOTONIC_RAW` with `_CLOCK_MONOTONIC` makes code more portable I guess. `CLOCK_MONOTONIC_RAW` does not resolve in darwin.
